### PR TITLE
Move away from ReplaySubject's when sending `self`

### DIFF
--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -6,7 +6,6 @@ import Nimble
 
 // Required Frameworks
 import RxSwift
-import RxCocoa
 
 // Framework To Be Test
 import RxViewModel

--- a/Pod/Classes/RxViewModel.swift
+++ b/Pod/Classes/RxViewModel.swift
@@ -25,10 +25,10 @@ public class RxViewModel: NSObject {
   var disposeBag = DisposeBag()
   
   /// The subject for active «signals»
-  private var activeSubject: ReplaySubject<RxViewModel>?
+  private var activeSubject: PublishSubject<RxViewModel>?
   
   /// The subject for the inactive «signals»
-  private var inactiveSubject: ReplaySubject<RxViewModel>?
+  private var inactiveSubject: PublishSubject<RxViewModel>?
   
   /// Underlying variable that we'll listen to for changes
   private dynamic var _active: Bool = false
@@ -90,7 +90,7 @@ public class RxViewModel: NSObject {
       return Observable.deferred { [weak self] () -> Observable<RxViewModel> in
         if let weakSelf = self
           where weakSelf.activeSubject == nil {
-            weakSelf.activeSubject = ReplaySubject.create(bufferSize: 1)
+            weakSelf.activeSubject = PublishSubject()
             
             return weakSelf.activeSubject!
         }
@@ -110,7 +110,7 @@ public class RxViewModel: NSObject {
       return Observable.deferred { [weak self] () -> Observable<RxViewModel> in
         if let weakSelf = self
           where weakSelf.inactiveSubject == nil {
-            weakSelf.inactiveSubject = ReplaySubject.create(bufferSize: 1)
+            weakSelf.inactiveSubject = PublishSubject()
             
             return weakSelf.inactiveSubject!
         }

--- a/Pod/Classes/RxViewModel.swift
+++ b/Pod/Classes/RxViewModel.swift
@@ -66,7 +66,6 @@ public class RxViewModel: NSObject {
     return self.activeObservable
         .filter { $0 == true }
         .map { _ in return self }
-        .shareReplayLatestWhileConnected()
   }()
   
   /**
@@ -78,7 +77,6 @@ public class RxViewModel: NSObject {
     return self.activeObservable
         .filter { $0 == false }
         .map { _ in return self }
-        .shareReplayLatestWhileConnected()
   }()
   
   /**


### PR DESCRIPTION
Since `self` was being sent to the subjects with a buffer of 1, it was
holding itself in the subjects indefinitely. The weakSelf I added in #30
only affects the closure itself, not the memory semantics of the subject
storing itself.

Looking back at RVMViewModel, they didn't have these as a replay
subject, so I changed them to publish subjects to match their semantics.

The throttling observable can keep it's subject since it's not sending
values of self.

I *think* this is correct, but please correct me on any of this. :)