### PR TITLE
Fix carthage missing dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,8 @@ DerivedData
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
+Carthage/Checkouts
+Carthage/Build
 
 Carthage/Build
 Demo/Pods

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Carthage/Checkouts/RxSwift"]
-	path = Carthage/Checkouts/RxSwift
-	url = https://github.com/ReactiveX/RxSwift.git

--- a/RxViewModel.xcodeproj/project.pbxproj
+++ b/RxViewModel.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1168B9BF1D2E089000784841 /* Observable_Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168B9BD1D2E089000784841 /* Observable_Operations.swift */; };
 		1168B9C01D2E089000784841 /* RxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168B9BE1D2E089000784841 /* RxViewModel.swift */; };
 		1168B9C51D2E089600784841 /* RxViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 1168B9C31D2E089600784841 /* RxViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5A454A901D7DFC2100556882 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A454A8F1D7DFC2100556882 /* RxSwift.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -18,6 +19,7 @@
 		1168B9BE1D2E089000784841 /* RxViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxViewModel.swift; sourceTree = "<group>"; };
 		1168B9C21D2E089600784841 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1168B9C31D2E089600784841 /* RxViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RxViewModel.h; sourceTree = "<group>"; };
+		5A454A8F1D7DFC2100556882 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -25,6 +27,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A454A901D7DFC2100556882 /* RxSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -37,6 +40,7 @@
 				1168B9C11D2E089600784841 /* Supporting Files */,
 				1168B9BB1D2E089000784841 /* Source */,
 				1168B9B11D2E081800784841 /* Products */,
+				5A454A8E1D7DFC2000556882 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -72,6 +76,14 @@
 				1168B9C31D2E089600784841 /* RxViewModel.h */,
 			);
 			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		5A454A8E1D7DFC2000556882 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				5A454A8F1D7DFC2100556882 /* RxSwift.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -259,6 +271,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = "$(SRCROOT)/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -276,6 +292,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = "$(SRCROOT)/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";


### PR DESCRIPTION
## Issue

There was a missing dependency in the carthage project and the command `carthage build` was failing.
## How to reproduce

You can verify by running the command `carthage build --no-skip-current` . 
It fails with the error:

```
...RxViewModel/Source/RxViewModel.swift:13:8: error: no such module 'RxSwift'
...RxViewModel/Source/RxViewModel.swift:13:8: error: no such module 'RxSwift'
```
## Fix

I just added the missing dependency `RxSwift` as linked framework and removed the carthage artefacts from git to be able to test the build
