### PR TITLE
🐛 Marks `RxViewModel` as `open`

### DIFF
--- a/Source/RxViewModel.swift
+++ b/Source/RxViewModel.swift
@@ -16,7 +16,7 @@ import RxSwift
 Implements behaviors that drive the UI, and/or adapts a domain model to be 
 user-presentable.
 */
-public class RxViewModel: NSObject {
+open class RxViewModel: NSObject {
   // MARK: Constants
   let throttleTime: TimeInterval = 2
   

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,9 @@
 codecov:
-  branch: master
+  notify:
+    require_ci_to_pass: yes
 comment:
   layout: "header, changes, diff, sunburst"
+
 coverage:
   ignore:
   - Pods/.*
@@ -12,12 +14,10 @@ coverage:
   - .*Tests.swift
   - '# Add the folders containing your unit tests'
   - '# This ensures any test utility classes you create are also ignored'
-  - Demo/Tests/*
-  - Demo/Pods/*
-  - Demo/Build/*
+  - Demo/Demo/Tests/*
+  - Demo/Demo/Pods/*
+  - Demo/Demo/Build/*
+  - Demo/Demo/*
   status:
     patch: false
-notify:
-  webhook:
-    default:
-      url: https://codecov.io/webhooks/github
+


### PR DESCRIPTION
When `RxViewModel` was created `Swift` only had 3 access levels; and
thus marking it as `public` would suffice for subclassing; with `Swift`
3 this changed and we never got around modifying the access level on the
class to be `open` as reported on #50.