### PR TITLE
Loosen RxSwift to `~> 3.5` instead of `~> 3.5.0`

### DIFF
--- a/RxViewModel.podspec
+++ b/RxViewModel.podspec
@@ -25,6 +25,6 @@ Long story short: a blatant «imitation» of `ReactiveViewModel `using `RxCocoa`
   s.requires_arc = true
 
   s.source_files = 'Source/*.swift', 'Source/Categories/*.swift'
-  s.dependency 'RxSwift', '~> 3.5.0'
+  s.dependency 'RxSwift', '~> 3.5'
   s.frameworks = 'Foundation'
 end


### PR DESCRIPTION
RxViewModel takes `'RxSwift', '~> 3.5.0’` as a dependency

For Podfile versioning

~> 3.5.0 means 3.5.x up to 3.6

The latest RxSwift version is 3.6.1, so changes to ‘~> 3.5` which practically means 3.5 up to 4.0 (whenever that is released we can address separately).